### PR TITLE
Add required tsconfig.json file in custom init guide

### DIFF
--- a/pages/docs/2_modify/1_getting_started/3_custom_init.md
+++ b/pages/docs/2_modify/1_getting_started/3_custom_init.md
@@ -31,6 +31,37 @@ We recommend to also **install TypeScript** as a dev dependency:
 $ npm install -D typescript
 ```
 
+Add a `tsconfig.json` file with the following contents:
+```text
+{
+  "compileOnSave": true,
+  "compilerOptions": {
+    "module": "commonjs",
+    "lib": [
+      "es6",
+      "dom"
+    ],
+    "target": "es2017",
+    "noImplicitAny": true,
+    "removeComments": false,
+    "preserveConstEnums": true,
+    "sourceMap": true,
+    "inlineSources": true,
+    "declaration": true
+  },
+  "include": [
+    "index.ts",
+    "lib/**/*",
+    "bin/**/*"
+  ],
+  "exclude": [
+    "**/node_modules",
+    "**/test/*"
+  ]
+}
+```
+
+
 <div class="note">
 If your custom config also depends on other packages
 that are not included in Comunica SPARQL,


### PR DESCRIPTION
Added the step for the required file `tsconfig.json` that was not mentioned in this guide.