### PR TITLE
Updating some dead links and redirects on usage page

### DIFF
--- a/pages/docs/1_query/2_usage.md
+++ b/pages/docs/1_query/2_usage.md
@@ -25,10 +25,10 @@ which can then be executed by any SPARQL query engine [such as Comunica](https:/
 It can also be used execute [authenticated queries over Solid data pods](https://github.com/rubensworks/GraphQL-LD-Comunica-Solid.js),
 for which [reusable React components](https://github.com/rubensworks/solid-react-graphql-ld.js) are available.
 
-## Node Quadstore
+## Quadstore
 
-[Node Quadstore](https://github.com/belayeng/quadstore) is a [LevelDB](https://github.com/google/leveldb)-based graph database for Node.js and the browser.
-[Node Quadstore Comunica](https://github.com/belayeng/quadstore-comunica) is a SPARQL engine on top of Node Quadstore that is powered by Comunica.
+[Quadstore](https://github.com/belayeng/quadstore) is a [LevelDB](https://github.com/google/leveldb)-based graph database for Node.js and the browser.
+[Quadstore Comunica](https://github.com/belayeng/quadstore-comunica) is a SPARQL engine on top of Quadstore that is powered by Comunica.
 
 ## RDF Parse
 

--- a/pages/docs/1_query/2_usage.md
+++ b/pages/docs/1_query/2_usage.md
@@ -27,8 +27,8 @@ for which [reusable React components](https://github.com/rubensworks/solid-react
 
 ## Node Quadstore
 
-[Node Quadstore](https://github.com/beautifulinteractions/node-quadstore) is a [LevelDB](https://github.com/google/leveldb-backed) graph database for Node.js and the browser.
-[Node Quadstore SPARQL](https://github.com/beautifulinteractions/node-quadstore-sparql) is a SPARQL engine on top of Node Quadstore that is powered by Comunica.
+[Node Quadstore](https://github.com/belayeng/quadstore) is a [LevelDB](https://github.com/google/leveldb)-based graph database for Node.js and the browser.
+[Node Quadstore Comunica](https://github.com/belayeng/quadstore-comunica) is a SPARQL engine on top of Node Quadstore that is powered by Comunica.
 
 ## RDF Parse
 


### PR DESCRIPTION
I was looking around the documentation and noticed some of the links were giving 404s and a redirect in the usage page.

The leveldb link looks like a typo, while I guess there has been a change of group on quadstore, while the node-quadstore-sparql is now replaced or renamed?