### PR TITLE
Fixes broken client-side date rendering in Safari due to unsupported date format

### DIFF
--- a/components/BlogIndex.js
+++ b/components/BlogIndex.js
@@ -10,7 +10,7 @@ export default function DocIndex ({ path, paths, mattersData }) {
             const [_, year, month, day] = /^([0-9][0-9][0-9][0-9])-([0-9][0-9])-([0-9][0-9])-/.exec(p);
             return {
                 path: p,
-                date: `${new Date(`${month} ${day} ${year}`)
+                date: `${new Date(`${year}-${month}-${day}`)
                     .toLocaleDateString("en-US", { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' })}`,
                 title: mattersData[path + '/' + p].title,
                 excerpt: mattersData[path + '/' + p].excerpt,


### PR DESCRIPTION
Basically, the `Date()` constructor was being called with the US date format `mm dd yyyy` which is not supported by Safari. See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/Date#timestamp_string . I've replaced it with a partial ISO 8601 representation, which is supported by all browsers.