### PR TITLE
Fix typo that was resulting on page not found

### DIFF
--- a/pages/docs/2_modify/1_getting_started/3_custom_init.md
+++ b/pages/docs/2_modify/1_getting_started/3_custom_init.md
@@ -28,7 +28,7 @@ $ npm install @comunica/query-sparql
 
 <div class="note">
 If you want to create a more lightweight package by selecting only those dependencies that are absolutely required,
-you can make use of the <a href="https://github.com/comunica/comunica/blob/master/packager/packager">Comunica Packager</a>.
+you can make use of the <a href="https://github.com/comunica/comunica/tree/master/packages/packager">Comunica Packager</a>.
 </div>
 
 We recommend to also **install TypeScript** as a dev dependency:


### PR DESCRIPTION
From https://github.com/comunica/comunica/tree/master/packager/packager to https://github.com/comunica/comunica/tree/master/packages/packager