### PR TITLE
Add lerna-linker explanation to website

### DIFF
--- a/pages/docs/2_modify/advanced/extending_local_version_comunica.md
+++ b/pages/docs/2_modify/advanced/extending_local_version_comunica.md
@@ -1,0 +1,52 @@
+---
+title: 'Using Local Changes to Base Comunica in Comunica Extensions'
+description: 'Guide on how to extend a local version of Comunica or use a local version of Comunica with an existing extension'
+---
+
+Various  [extensions](https://comunica.dev/docs/modify/extensions/) of Comunica exist. 
+These extensions utilize packages from the [base Comunica](https://github.com/comunica/comunica) framework and add additional packages or engine configurations. 
+When working on local changes to the base Comunica and needing to use these changes in an extension, you must link your local development version of Comunica with your extension project.
+This page introduces some methods to achieve this, though other methods are possible.
+
+## Lerna-linker
+
+Lerna-linker is a script designed to facilitate package linking in a Lerna monorepo. It iterates over all packages, executing `yarn unlink` and `yarn link` on each. It then saves all linked packages and runs `yarn link <package>` for each linked package in the Comunica extension.
+
+### Installation
+
+Install the script globally using the following:
+
+```bash
+$ npm install -g lerna-linker
+```
+
+### Usage
+
+Assume the local version of Comunica is located at `path/to/comunica` and the extension at `path/to/comunica-extension`.
+
+1. Link Source Packages by navigating to the base Comunica directory and running:
+
+ ```bash 
+    $ cd path/to/comunica
+    $ lerna-linker linkSource 
+ ```
+
+ This command links all packages in the base repository.
+2. Link source packages to target by moving to the Comunica extension directory and running:
+
+ ```bash
+    $ cd path/to/comunica-extension
+    $ lerna-linker linkTarget
+ ```
+
+ This command links the base Comunica packages to the extension.
+
+3. Undo Linking of the base Comunica packages by navigating to the Comunica extension directory and running:
+ ```bash
+    $ cd path/to/comunica-extension
+    $ lerna-linker unlinkTarget
+ ```
+
+ This command will unlink the base Comunica packages from the extension.
+
+By following these steps, you can effectively manage local changes to the base Comunica framework and ensure they are utilized within your extensions. Note that linking multiple different development versions simultaneously does not work, as running `$ lerna-linker linkSource` will overwrite all previously made links.

--- a/pages/docs/2_modify/advanced/extending_local_version_comunica.md
+++ b/pages/docs/2_modify/advanced/extending_local_version_comunica.md
@@ -1,9 +1,9 @@
 ---
-title: 'Using Local Changes to Base Comunica in Comunica Extensions'
-description: 'Guide on how to extend a local version of Comunica or use a local version of Comunica with an existing extension'
+title: 'Linking Comunica development environment to other projects
+description: 'Guide on how to use a local development version of Comunica with another local project'
 ---
 
-Various  [extensions](https://comunica.dev/docs/modify/extensions/) of Comunica exist. 
+Various [extensions](https://comunica.dev/docs/modify/extensions/) of Comunica exist. 
 These extensions utilize packages from the [base Comunica](https://github.com/comunica/comunica) framework and add additional packages or engine configurations. 
 When working on local changes to the base Comunica and needing to use these changes in an extension, you must link your local development version of Comunica with your extension project.
 This page introduces some methods to achieve this, though other methods are possible.
@@ -22,7 +22,7 @@ $ npm install -g lerna-linker
 
 ### Usage
 
-Assume the local version of Comunica is located at `path/to/comunica` and the extension at `path/to/comunica-extension`.
+Assume the local version of Comunica is located at `path/to/comunica` and the extension at `path/to/my-project`.
 
 1. Link Source Packages by navigating to the base Comunica directory and running:
 

--- a/pages/docs/2_modify/advanced/extending_local_version_comunica.md
+++ b/pages/docs/2_modify/advanced/extending_local_version_comunica.md
@@ -1,12 +1,13 @@
 ---
-title: 'Linking Comunica development environment to other projects
+title: 'Linking local Comunica versions to other projects'
 description: 'Guide on how to use a local development version of Comunica with another local project'
 ---
 
-Various [extensions](https://comunica.dev/docs/modify/extensions/) of Comunica exist. 
-These extensions utilize packages from the [base Comunica](https://github.com/comunica/comunica) framework and add additional packages or engine configurations. 
-When working on local changes to the base Comunica and needing to use these changes in an extension, you must link your local development version of Comunica with your extension project.
-This page introduces some methods to achieve this, though other methods are possible.
+In cases where a local development version of Comunica is consumed as a dependency of another project, linking the local development version of Comunica to the project is required.
+
+For example, various extensions of Comunica exist. These extensions utilize packages from the base Comunica framework and add additional packages or engine configurations. When working on local changes to base Comunica and needing to use these changes in an extension, you must link the local development version of  Comunica with the extension project. This page introduces a method to achieve this, though other methods are possible.
+
+This method does not require publishing the development version of Comunica to NPM, thus it is useful for testing changes before they are made public.
 
 ## Lerna-linker
 
@@ -43,10 +44,16 @@ Assume the local version of Comunica is located at `path/to/comunica` and the ex
 
 3. Undo Linking of the base Comunica packages by navigating to the Comunica extension directory and running:
  ```bash
-    $ cd path/to/comunica-extension
-    $ lerna-linker unlinkTarget
+    $ cd path/to/comunica-extension
+    $ lerna-linker unlinkTarget
+    $ yarn install
+
  ```
 
  This command will unlink the base Comunica packages from the extension.
 
-By following these steps, you can effectively manage local changes to the base Comunica framework and ensure they are utilized within your extensions. Note that linking multiple different development versions simultaneously does not work, as running `$ lerna-linker linkSource` will overwrite all previously made links.
+By following these steps, you can effectively manage local changes to the base Comunica framework and ensure they are utilized within the extensions. 
+
+<div class="note">
+Linking multiple different development versions simultaneously will not work, as running <code>$lerna-linker linkSource</code> will overwrite all previously made links.
+</div>

--- a/pages/docs/2_modify/advanced/linking_local_version.md
+++ b/pages/docs/2_modify/advanced/linking_local_version.md
@@ -12,7 +12,7 @@ This method does not require publishing the development version of Comunica to N
 
 ## Lerna-linker
 
-Lerna-linker is a script designed to facilitate package linking in a Lerna monorepo. It iterates over all packages, executing `yarn unlink` and `yarn link` on each. It then saves all linked packages and runs `yarn link <package>` for each linked package in the Comunica extension.
+[lerna-linker](https://www.npmjs.com/package/lerna-linker) is a script designed to facilitate package linking in a Lerna monorepo. It iterates over all packages, executing `yarn unlink` and `yarn link` on each. It then saves all linked packages and runs `yarn link <package>` for each linked package in the Comunica extension.
 
 ### Installation
 

--- a/pages/docs/2_modify/advanced/linking_local_version.md
+++ b/pages/docs/2_modify/advanced/linking_local_version.md
@@ -3,6 +3,7 @@ title: 'Linking local Comunica versions to other projects'
 description: 'Guide on how to use a local development version of Comunica with another local project'
 ---
 
+
 In cases where a local development version of Comunica is consumed as a dependency of another project, linking the local development version of Comunica to the project is required.
 
 For example, various extensions of Comunica exist. These extensions utilize packages from the base Comunica framework and add additional packages or engine configurations. When working on local changes to base Comunica and needing to use these changes in an extension, you must link the local development version of  Comunica with the extension project. This page introduces a method to achieve this, though other methods are possible.


### PR DESCRIPTION
As the title suggests, I added a new page explaining how to use a local version of base Comunica in an extension of Comunica (like link-traversal). It is intended that other methods are added to this page (like the workspaces approach from @surilindur) . 