### PR TITLE
Repair interlinks in the docs

### DIFF
--- a/pages/docs/2_modify/1_getting_started/5_contribute_actor.md
+++ b/pages/docs/2_modify/1_getting_started/5_contribute_actor.md
@@ -5,7 +5,7 @@ description: 'Setup a development environment, implement a new actor, and create
 
 This guide focuses on all the required steps for contributing a new query operation actor to Comunica,
 restricting itself to the contribution of an operator that can be parsed by Comunica.
-To implement an actor for a new operator that Comunica can not yet parse, read [contribute new operation](./7_contribute_new_operation.md).
+To implement an actor for a new operator that Comunica can not yet parse, read [contribute new operation](https://comunica.dev/docs/modify/getting_started/contribute_new_operation).
 Concretely, we will focus on implementing a custom actor for the SPARQL `REDUCED` operator.
 
 <div class="note">

--- a/pages/docs/2_modify/1_getting_started/7_contribute_new_operation.md
+++ b/pages/docs/2_modify/1_getting_started/7_contribute_new_operation.md
@@ -22,7 +22,7 @@ To fully understand this guide, we strongly recommend reading
 
 ## 1. Getting started
 
-First, set up your development environment by following sections 1 and 2 of [_contributing an actor_](5_contribute_actor.md#1-requirements).
+First, set up your development environment by following sections 1 and 2 of [_contributing an actor_](https://comunica.dev/docs/modify/getting_started/contribute_actor/#1--requirements).
 Next, [create a new actor package](https://comunica.dev/docs/modify/getting_started/contribute_actor/#3--creating-a-new-package):
 ```yo comunica:actor```.
 Configure the actor with name `lateral` on bus `query-parse`, you can agree with the default options the program suggests.
@@ -235,7 +235,7 @@ import { toComunicaAlgebra as toAlgebra, ComunicaSparqlParser as SparqlParser } 
 
 ## 3. Replace the original parse actor with yours
 
-In [section 6 of contributing an actor](./5_contribute_actor.md#6-configuring-your-actor)
+In [section 6 of contributing an actor](https://comunica.dev/docs/modify/getting_started/contribute_actor/#6--configuring-your-actor)
 you learned about the dependency injection framework used by Comunica.
 You may now configure your parsing actor in a similar way:
 * Add it as a dependency in `engines/query-sparql/package.json`, and remove the original `@comunica/actor-query-parse-sparql`.
@@ -247,12 +247,12 @@ all that's left is implementing the actor that perform the operation.
 ## 4. Implementing the LATERAL actor
 
 Implementing the execution logic now follows the standard guide:
-[implementing your own actor query operation](5_contribute_actor.md#4-implementing-your-actor).
+[implementing your own actor query operation](https://comunica.dev/docs/modify/getting_started/contribute_actor/#4--implementing-your-actor).
 You should just make sure that the generic type passed to `ActorQueryOperationTypedMediated` is your `Lateral` type.
 
 ## 5. Testing with Comunica SPARQL
 
-Just like [section 7 of contributing an actor](./5_contribute_actor.md#7-testing-with-comunica-sparql),
+Just like [section 7 of contributing an actor](https://comunica.dev/docs/modify/getting_started/contribute_actor/#7--testing-with-comunica-sparql),
 we need to make sure our actor works before we create a pull request.
 Simply rebuild your engine as described there, and test that it works on a query using `LATERAL`.
 ```bash

--- a/pages/docs/2_modify/advanced/algebra.md
+++ b/pages/docs/2_modify/advanced/algebra.md
@@ -83,4 +83,4 @@ This tool is therefore useful if you want to implement support for a SPARQL oper
 but you need to find out to what algebra operation this corresponds.
 
 > [!note]
-> Before implementing support for a SPARQL operator, read our tutorial on [contributing an actor](../1_getting_started/5_contribute_actor.md) and [contributing a new operator](../1_getting_started/7_contribute_new_operation.md).
+> Before implementing support for a SPARQL operator, read our tutorial on [contributing an actor](https://comunica.dev/docs/modify/getting_started/contribute_actor) and [contributing a new operator](https://comunica.dev/docs/modify/getting_started/contribute_new_operation).


### PR DESCRIPTION
Some links were broken because next.js doesn't rewrite markdown links in html anchors. I tried to add support for it in components but didn't like the code. So i just replaced broken links with public URLs.

for context, here's the solution i dismissed. it repaired the links, but even if cleaned up it could always touch some link it shouldn't and mangle source, so i think public URLs in markdown is better direction. 

```js
// components/Markdown.js
const Link = ({node, href, children, ...props}) => {
    if (href && href.includes('.md')) {
        href = href
            .replace(/\.md(#|$)/, '/$1')
            .replace(/(^|\/)\.\.\/(?!\.)/g, '$1../../')
            .replace(/(^|\/)[0-9]*_/g, '$1');
        if (!/^(\/|\.\.\/|https?:\/\/|#)/.test(href)) {
            href = '../' + href;
        }
    }
    return <a href={href} {...props}>{children}</a>;
};
```